### PR TITLE
Fix: Remove unsupported formats from scanner

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,7 +20,7 @@ def find_ebooks_in_calibre_library(calibre_library_path, supported_formats=None)
         list: List of full file paths to the ebooks found.
     """
     if supported_formats is None:
-        supported_formats = ['epub', 'mobi', 'pdf', 'azw3', 'fb2']  # Default formats
+        supported_formats = ['epub', 'mobi', 'azw3']  # Only formats supported by apply_bioread.py
 
     ebook_paths = []
 


### PR DESCRIPTION
## Summary
- Removes PDF and FB2 from the supported formats list
- Only scans for formats that apply_bioread.py actually supports (epub, mobi, azw3)

## Problem
The scanner was finding PDF files (Calibre metadata/cover files) and other unsupported formats, which would fail during conversion since apply_bioread.py only supports epub, mobi, and azw3.

## Solution
Updated the default supported_formats list to only include formats that can actually be converted.

## Test plan
- [x] Verify only epub, mobi, azw3 files are scanned
- [x] Confirm PDF files no longer appear in search results

🤖 Generated with [Claude Code](https://claude.com/claude-code)