### PR TITLE
Harden kepub conversion: version guard, version logging, integration test, clean failures

### DIFF
--- a/apply_bioread.py
+++ b/apply_bioread.py
@@ -323,7 +323,15 @@ def convert_to_kepub(epub_path):
 
     base, _ = os.path.splitext(epub_path)
     kepub_path = f"{base}.kepub.epub"
-    subprocess.run(["kepubify", "-o", kepub_path, epub_path], check=True)
+    try:
+        subprocess.run(["kepubify", "-o", kepub_path, epub_path], check=True)
+    except subprocess.CalledProcessError as error:
+        print(
+            f"kepubify failed (exit {error.returncode}) converting "
+            f"'{epub_path}'. The plain epub is kept so the run is recoverable, "
+            "but it freezes Kobo devices and must NOT be sideloaded as-is."
+        )
+        sys.exit(1)
 
     if not os.path.isfile(kepub_path):
         print(f"kepubify did not produce expected output at '{kepub_path}'.")

--- a/apply_bioread.py
+++ b/apply_bioread.py
@@ -292,6 +292,36 @@ def process_htmlz(input_file, output_file, original_format, font_path=None, font
         subprocess.run(cmd_convert_back, check=True)
 
 
+# The single-file `-o <file>` output contract this tool relies on was
+# verified on kepubify 4.x. Guard against older majors that behave differently.
+MIN_KEPUBIFY_MAJOR = 4
+
+
+def _tool_version(command):
+    """Return the first line of ``<command> --version``, or None.
+
+    Best-effort and never raises: used only for version logging and the
+    kepubify guard, so a missing/odd tool degrades gracefully.
+    """
+    try:
+        result = subprocess.run(
+            list(command) + ["--version"],
+            capture_output=True, text=True, check=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    output = (result.stdout or result.stderr or "").strip()
+    return output.splitlines()[0] if output else None
+
+
+def _kepubify_major(version_line):
+    """Extract the integer major version from a ``kepubify X.Y.Z`` line."""
+    if not version_line:
+        return None
+    match = re.search(r"(\d+)\.\d+", version_line)
+    return int(match.group(1)) if match else None
+
+
 def convert_to_kepub(epub_path):
     """
     Converts a plain ``.epub`` to Kobo's ``.kepub.epub`` format using kepubify.
@@ -318,6 +348,16 @@ def convert_to_kepub(epub_path):
             "Missing dependency: kepubify. The plain-epub output left at "
             f"'{epub_path}' freezes Kobo devices and must NOT be sideloaded.\n"
             "Install it and re-run: brew install kepubify"
+        )
+        sys.exit(1)
+
+    version_line = _tool_version(["kepubify"])
+    major = _kepubify_major(version_line)
+    if major is not None and major < MIN_KEPUBIFY_MAJOR:
+        print(
+            f"kepubify '{version_line}' is too old. This tool relies on the "
+            f"-o <file> output contract verified on {MIN_KEPUBIFY_MAJOR}.x. "
+            "Upgrade and re-run: brew upgrade kepubify"
         )
         sys.exit(1)
 

--- a/apply_bioread.py
+++ b/apply_bioread.py
@@ -322,6 +322,19 @@ def _kepubify_major(version_line):
     return int(match.group(1)) if match else None
 
 
+def log_tool_versions():
+    """Print the external converter versions a run depends on.
+
+    Output is reproducibility-critical: a calibre or kepubify upgrade can
+    silently change the produced ebook (CACE), so each run records which
+    tool versions made it.
+    """
+    for label, binary in (("calibre ebook-convert", "ebook-convert"),
+                           ("kepubify", "kepubify")):
+        version = _tool_version([binary]) if shutil.which(binary) else None
+        print(f"[tool] {label}: {version or 'not found'}")
+
+
 def convert_to_kepub(epub_path):
     """
     Converts a plain ``.epub`` to Kobo's ``.kepub.epub`` format using kepubify.
@@ -403,6 +416,8 @@ def main():
     if file_ext.lower() not in supported_formats:
         print("Supported input formats are .epub, .mobi, and .azw3.")
         sys.exit(1)
+
+    log_tool_versions()
 
     output_file = f"{file_name}_fastread{file_ext}"
     process_htmlz(input_file, output_file, file_ext.lower()[1:], font_path=font_path, font_dir=font_dir)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+markers =
+    unit: fast tests with no external binaries
+    integration: drives real external tools (kepubify, calibre); skipped if absent
+    slow: long-running tests

--- a/tests/test_kepub_output.py
+++ b/tests/test_kepub_output.py
@@ -8,7 +8,9 @@ pre-fix code path.
 """
 
 import os
+import shutil
 import sys
+import zipfile
 from unittest import mock
 
 import pytest
@@ -131,4 +133,52 @@ def test_log_tool_versions_missing_tool_is_not_fatal(capsys):
 
     out = capsys.readouterr().out
     assert "kepubify: not found" in out
+
+
+def _write_minimal_epub(path):
+    """Build the smallest spec-valid epub kepubify will accept."""
+    with zipfile.ZipFile(path, "w") as zf:
+        # mimetype must be first and stored (uncompressed).
+        zf.writestr(zipfile.ZipInfo("mimetype"), "application/epub+zip",
+                    compress_type=zipfile.ZIP_STORED)
+        zf.writestr("META-INF/container.xml",
+                    '<?xml version="1.0"?><container version="1.0" '
+                    'xmlns="urn:oasis:names:tc:opendocument:xmlns:container">'
+                    '<rootfiles><rootfile full-path="content.opf" '
+                    'media-type="application/oebps-package+xml"/></rootfiles></container>')
+        zf.writestr("content.opf",
+                    '<?xml version="1.0"?><package '
+                    'xmlns="http://www.idpf.org/2007/opf" version="3.0" '
+                    'unique-identifier="id"><metadata '
+                    'xmlns:dc="http://purl.org/dc/elements/1.1/">'
+                    '<dc:identifier id="id">x</dc:identifier><dc:title>t</dc:title>'
+                    '<dc:language>en</dc:language></metadata><manifest>'
+                    '<item id="c" href="c.xhtml" media-type="application/xhtml+xml"/>'
+                    '</manifest><spine><itemref idref="c"/></spine></package>')
+        zf.writestr("c.xhtml",
+                    '<?xml version="1.0"?><html '
+                    'xmlns="http://www.w3.org/1999/xhtml"><body><p>hi</p></body></html>')
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(shutil.which("kepubify") is None,
+                    reason="kepubify not installed")
+def test_real_kepubify_o_file_contract(tmp_path):
+    """End-to-end check of the real `kepubify -o <file>` contract.
+
+    The unit tests mock subprocess, so nothing else catches a kepubify CLI
+    change (e.g. -o no longer accepting a full file path). This drives the
+    real binary against a real epub.
+    """
+    plain = tmp_path / "Book_fastread.epub"
+    _write_minimal_epub(plain)
+
+    result = apply_bioread.convert_to_kepub(str(plain))
+
+    expected = tmp_path / "Book_fastread.kepub.epub"
+    assert result == str(expected)
+    assert expected.is_file(), "kepubify -o <file> must produce exactly that path"
+    assert not plain.exists(), "plain intermediate must be removed"
+    with zipfile.ZipFile(expected) as zf:
+        assert zf.testzip() is None, "produced kepub must be a valid zip"
 

--- a/tests/test_kepub_output.py
+++ b/tests/test_kepub_output.py
@@ -36,9 +36,10 @@ def test_main_emits_kepub_and_removes_plain_epub(tmp_path):
     kepub = tmp_path / "Book_fastread.kepub.epub"
 
     def fake_run(cmd, check=False, **kwargs):
-        assert cmd[0] == "kepubify"
         if "--version" in cmd:
-            return mock.Mock(returncode=0, stdout="kepubify 4.0.4\n", stderr="")
+            # log_tool_versions() probes ebook-convert and kepubify.
+            return mock.Mock(returncode=0, stdout=f"{cmd[0]} 4.0.4\n", stderr="")
+        assert cmd[0] == "kepubify"
         out_path = cmd[cmd.index("-o") + 1]
         with open(out_path, "wb") as handle:
             handle.write(b"PK\x03\x04 kepub bytes")
@@ -79,6 +80,7 @@ def test_non_epub_output_is_left_untouched(tmp_path):
 
     with mock.patch.object(apply_bioread, "process_htmlz",
                            _fake_process_htmlz(str(produced))), \
+         mock.patch.object(apply_bioread, "log_tool_versions"), \
          mock.patch.object(apply_bioread, "convert_to_kepub") as conv, \
          mock.patch.object(sys, "argv", ["apply_bioread.py", str(book)]):
         apply_bioread.main()
@@ -107,4 +109,26 @@ def test_old_kepubify_major_is_rejected(tmp_path):
 
     assert exc.value.code == 1
     assert plain.exists(), "plain epub kept so the failure is recoverable"
+
+
+def test_log_tool_versions_records_both_tools(capsys):
+    """Each run must record the calibre + kepubify versions it depended on."""
+    def fake_run(cmd, check=False, **kwargs):
+        return mock.Mock(returncode=0, stdout=f"{cmd[0]} 9.9.9\n", stderr="")
+
+    with mock.patch.object(apply_bioread.shutil, "which", return_value="/bin/x"), \
+         mock.patch.object(apply_bioread.subprocess, "run", side_effect=fake_run):
+        apply_bioread.log_tool_versions()
+
+    out = capsys.readouterr().out
+    assert "calibre ebook-convert: ebook-convert 9.9.9" in out
+    assert "kepubify: kepubify 9.9.9" in out
+
+
+def test_log_tool_versions_missing_tool_is_not_fatal(capsys):
+    with mock.patch.object(apply_bioread.shutil, "which", return_value=None):
+        apply_bioread.log_tool_versions()  # must not raise
+
+    out = capsys.readouterr().out
+    assert "kepubify: not found" in out
 

--- a/tests/test_kepub_output.py
+++ b/tests/test_kepub_output.py
@@ -36,8 +36,9 @@ def test_main_emits_kepub_and_removes_plain_epub(tmp_path):
     kepub = tmp_path / "Book_fastread.kepub.epub"
 
     def fake_run(cmd, check=False, **kwargs):
-        # The only subprocess in the patched path is kepubify.
         assert cmd[0] == "kepubify"
+        if "--version" in cmd:
+            return mock.Mock(returncode=0, stdout="kepubify 4.0.4\n", stderr="")
         out_path = cmd[cmd.index("-o") + 1]
         with open(out_path, "wb") as handle:
             handle.write(b"PK\x03\x04 kepub bytes")
@@ -84,3 +85,26 @@ def test_non_epub_output_is_left_untouched(tmp_path):
 
     conv.assert_not_called()
     assert produced.is_file()
+
+
+def test_old_kepubify_major_is_rejected(tmp_path):
+    """A kepubify older than the verified -o <file> contract must fail loudly."""
+    book = tmp_path / "Book.epub"
+    book.write_bytes(b"PK\x03\x04 source")
+    plain = tmp_path / "Book_fastread.epub"
+
+    def fake_run(cmd, check=False, **kwargs):
+        assert "--version" in cmd, "must reject before invoking conversion"
+        return mock.Mock(returncode=0, stdout="kepubify 3.1.6\n", stderr="")
+
+    with mock.patch.object(apply_bioread, "process_htmlz",
+                           _fake_process_htmlz(str(plain))), \
+         mock.patch.object(apply_bioread.shutil, "which", return_value="/usr/bin/kepubify"), \
+         mock.patch.object(apply_bioread.subprocess, "run", side_effect=fake_run), \
+         mock.patch.object(sys, "argv", ["apply_bioread.py", str(book)]):
+        with pytest.raises(SystemExit) as exc:
+            apply_bioread.main()
+
+    assert exc.value.code == 1
+    assert plain.exists(), "plain epub kept so the failure is recoverable"
+


### PR DESCRIPTION
Follow-up hardening from the tech-debt review of #16. Each commit is atomic and closes one issue.

- **Closes #15** — `convert_to_kepub` caught `kepubify` non-zero exits as a raw traceback; now fails consistently with a clear message, plain epub kept for recovery.
- **Closes #12** — guard against kepubify majors older than the verified `-o <file>` contract (`MIN_KEPUBIFY_MAJOR = 4`), best-effort version detection.
- **Closes #13** — `log_tool_versions()` records calibre + kepubify versions every run (CACE/reproducibility).
- **Closes #14** — opt-in integration test drives real kepubify against a real epub (skipif absent); `pytest.ini` registers unit/integration/slow markers.

7 tests pass (incl. real-kepubify integration); integration test verified to skip cleanly when kepubify is off PATH. gitleaks clean on every commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)